### PR TITLE
Add workflows

### DIFF
--- a/.github/workflows/build--and-publish-image.yaml
+++ b/.github/workflows/build--and-publish-image.yaml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: docker image build -t felix:$VERSION ./felix
+        run: docker image build
+          -t ghcr.io/acceptablesoftware/felix:$VERSION
+          ./felix
 
       - name: Publish image
         run: docker push ghcr.io/acceptablesoftware/felix:$VERSION

--- a/.github/workflows/build--and-publish-image.yaml
+++ b/.github/workflows/build--and-publish-image.yaml
@@ -1,0 +1,24 @@
+name: build-and-publish-image
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+    env:
+      VERSION: "1.0.0"
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker image build -t felix:$VERSION ./felix
+
+      - name: Publish image
+        run: docker push ghcr.io/acceptablesoftware/felix:$VERSION

--- a/.github/workflows/build--and-publish-image.yaml
+++ b/.github/workflows/build--and-publish-image.yaml
@@ -17,6 +17,13 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image
         run: docker image build
           -t ghcr.io/acceptablesoftware/felix:$VERSION

--- a/.github/workflows/build--and-publish-image.yaml
+++ b/.github/workflows/build--and-publish-image.yaml
@@ -1,8 +1,8 @@
 name: build-and-publish-image
 
 on:
-  push:
-    branches: [master]
+  - push
+    # branches: [master]
 
 jobs:
   build-and-publish-image:

--- a/.github/workflows/build--and-publish-image.yaml
+++ b/.github/workflows/build--and-publish-image.yaml
@@ -1,8 +1,8 @@
 name: build-and-publish-image
 
 on:
-  - push
-    # branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   build-and-publish-image:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   test-image-builds:
+    runs-on: ubuntu-20.04
+
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,12 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  test-image-builds:
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker image build -t felix:build-test ./felix

--- a/felix/Dockerfile
+++ b/felix/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.10.0-alpine3.14
-SDFA
 ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT /bin/sh

--- a/felix/Dockerfile
+++ b/felix/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10.0-alpine3.14
-
+SDFA
 ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT /bin/sh

--- a/felix/Dockerfile
+++ b/felix/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.10.0-alpine3.14
+
 ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT /bin/sh


### PR DESCRIPTION
This commit adds two workflows for building and publishing the Docker
image. The first workflow is `tests`, which is run on every push to
ensure the Docker image continues to build. The second workflow is
`build-and-publish-image` which only runs when something is merged into
the `master` branch. This builds the image and also publishes it to
GitHub packages.
