### PR TITLE
Use CMD instead of ENTRYPOINT

### DIFF
--- a/felix/Dockerfile
+++ b/felix/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /home/appuser
 # Do not buffer Python output and send it straight to the terminal.
 ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT /bin/sh
+CMD ["/bin/sh"]


### PR DESCRIPTION
Using ENTRYPOINT means that commands like
`docker container run -d --name felix sleep 1000` do not work for
some reason. Using CMD fixes this.