### PR TITLE
Always push image

### DIFF
--- a/.github/workflows/build-and-publish-image.yaml
+++ b/.github/workflows/build-and-publish-image.yaml
@@ -32,11 +32,5 @@ jobs:
           ./felix
 
       - name: Publish image
-        run:
-          # Prevent overwriting if the version already exists by
-          # inspecting the manifest.
-          docker manifest inspect
-            ghcr.io/acceptablesoftware/felix:${VERSION#v}
-          ||
-          docker push
+        run: docker push
             ghcr.io/acceptablesoftware/felix:${VERSION#v}


### PR DESCRIPTION
Because the image gets built only when a new tag is pushed
or when the workflow is dispatched, it can be assumed
that it is desirable for the new image to be pushed.